### PR TITLE
Remove UPX from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ go:
 - 1.12.x
 
 install:
-- sudo apt-get update
-- sudo apt-get install -y upx-ucl
 - curl -sL https://raw.githubusercontent.com/homeport/pina-golada/master/scripts/download-latest.sh | bash -s v1.2.3
 - curl -sL https://goo.gl/g1CpPX | bash -s v1.0.6 # Golang dev tools including pre-compiled Ginkgo and other useful tools
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -65,11 +65,6 @@ linux amd64
 windows amd64
 EOL
 
-if hash upx >/dev/null 2>&1; then
-  echo -e '\n\033[1mCompressing compiled binaries:\033[0m'
-  upx -9 binaries/*
-fi
-
 if hash file >/dev/null 2>&1; then
   echo -e '\n\033[1mFile details of compiled binaries:\033[0m'
   file binaries/*


### PR DESCRIPTION
Remove the installation and usage of `upx` in Travis for the build step. It seem
to cause issues when executing the binaries on other systems.