### PR TITLE
Bump tool versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ go:
 - 1.12.x
 
 install:
-- curl -sL https://raw.githubusercontent.com/homeport/pina-golada/master/scripts/download-latest.sh | bash -s v1.2.5
-- curl -sL https://goo.gl/g1CpPX | bash -s v1.0.6 # Golang dev tools including pre-compiled Ginkgo and other useful tools
+- curl -fsL https://ibm.biz/Bd2645 | bash -s v1.2.6
+- curl -fsL https://goo.gl/g1CpPX | bash -s v1.0.7
 
 script:
 - GO111MODULE=on go mod download
@@ -24,5 +24,5 @@ deploy:
   file_glob: true
   file: binaries/*
   on:
-    condition: $TRAVIS_GO_VERSION =~ ^1\.11
+    condition: $TRAVIS_GO_VERSION =~ ^1\.12
     tags: true


### PR DESCRIPTION
Bump pina-golada version used during build to v1.2.6

Bump Golang dev tools version used in Travis to v1.0.7

Bump Golang version used for build to 1.12