### PR TITLE
Fix make target clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ all: test build
 
 clean:
 	@rm -rf binaries
-	@GO111MODULE=on go clean -r -cache
+	@pina-golada cleanup
+	@GO111MODULE=on go clean -i -cache -testcache $(shell go list ./...)
 
 lint:
 	@scripts/go-lint.sh


### PR DESCRIPTION
Fix go clean call by removing the recursive flag for a go list call.