### PR TITLE
Introduce summary mode to gonut

### DIFF
--- a/internal/gonut/cf/models.go
+++ b/internal/gonut/cf/models.go
@@ -20,6 +20,8 @@
 
 package cf
 
+import "time"
+
 // AppCleanupSetting specifies supported cleanup options
 type AppCleanupSetting int
 
@@ -32,6 +34,46 @@ const (
 	Always
 	OnSuccess
 )
+
+// PushReport encapsules details of a Cloud Foundry push command
+type PushReport struct {
+	InitStart      time.Time
+	CreatingStart  time.Time
+	UploadingStart time.Time
+	StagingStart   time.Time
+	StartingStart  time.Time
+	PushEnd        time.Time
+}
+
+// InitTime is the time it takes to initialise the Cloud Foundry app push setup
+func (report PushReport) InitTime() time.Duration {
+	return report.CreatingStart.Sub(report.InitStart)
+}
+
+// CreatingTime is the time it takes to create the app in Cloud Foundry
+func (report PushReport) CreatingTime() time.Duration {
+	return report.UploadingStart.Sub(report.CreatingStart)
+}
+
+// UploadingTime is the time it takes to upload the app bits to Cloud Foundry
+func (report PushReport) UploadingTime() time.Duration {
+	return report.StagingStart.Sub(report.UploadingStart)
+}
+
+// StagingTime is the time it takes to stage (compile) the app in Cloud Foundry
+func (report PushReport) StagingTime() time.Duration {
+	return report.StartingStart.Sub(report.StagingStart)
+}
+
+// StartingTime is the time it takes to start the compiled app in Cloud Foundry
+func (report PushReport) StartingTime() time.Duration {
+	return report.PushEnd.Sub(report.StartingStart)
+}
+
+// ElapsedTime is the overall elapsed time it takes to push an app in Cloud Foundry
+func (report PushReport) ElapsedTime() time.Duration {
+	return report.PushEnd.Sub(report.InitStart)
+}
 
 // CloudFoundryConfig defines the structure used by the Cloud Foundry CLI configuration JSONs
 type CloudFoundryConfig struct {


### PR DESCRIPTION
Add code to measure the times of the respective sub-steps of a CF push.

Add Report struct to store all start times of the sub-steps.

Add output code to print details of the CF push report.