### PR TITLE
Improve error handling during CF push

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,5 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
-	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.3
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=

--- a/internal/gonut/cf/errors.go
+++ b/internal/gonut/cf/errors.go
@@ -1,0 +1,41 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cf
+
+import "fmt"
+
+// ErrorWithDetails is just that, an error with added details
+type ErrorWithDetails struct {
+	Caption string
+	Details string
+}
+
+func (e *ErrorWithDetails) Error() string {
+	return fmt.Sprintf("%s: %s", e.Caption, e.Details)
+}
+
+// Errorf creates a new error with details
+func Errorf(caption string, format string, args ...interface{}) error {
+	return &ErrorWithDetails{
+		Caption: caption,
+		Details: fmt.Sprintf(format, args...),
+	}
+}

--- a/internal/gonut/cmd/push.go
+++ b/internal/gonut/cmd/push.go
@@ -123,7 +123,7 @@ func init() {
 			Aliases: sampleApp.aliases,
 			Short:   fmt.Sprintf("Push a %s sample app to Cloud Foundry", sampleApp.caption),
 			Long:    fmt.Sprintf(`Push a %s sample app to Cloud Foundry. The application will be deleted after it was pushed successfully.`, sampleApp.caption),
-			RunE:    genericCommandFunc,
+			Run:     genericCommandFunc,
 		})
 	}
 
@@ -131,14 +131,12 @@ func init() {
 		Use:   "all",
 		Short: "Pushes all available sample apps to Cloud Foundry",
 		Long:  `Pushes all available sample apps to Cloud Foundry. Each application will be deleted after it was pushed successfully.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: func(cmd *cobra.Command, args []string) {
 			for _, sampleApp := range sampleApps {
 				if err := runSampleAppPush(sampleApp); err != nil {
-					return err
+					ExitGonut(err)
 				}
 			}
-
-			return nil
 		},
 	})
 }
@@ -153,13 +151,15 @@ func lookUpSampleAppByName(name string) *sampleApp {
 	return nil
 }
 
-func genericCommandFunc(cmd *cobra.Command, args []string) error {
+func genericCommandFunc(cmd *cobra.Command, args []string) {
 	sampleApp := lookUpSampleAppByName(cmd.Use)
 	if sampleApp == nil {
-		return fmt.Errorf("failed to detect which sample app is to be tested")
+		ExitGonut("failed to detect which sample app is to be tested")
 	}
 
-	return runSampleAppPush(*sampleApp)
+	if err := runSampleAppPush(*sampleApp); err != nil {
+		ExitGonut(err)
+	}
 }
 
 func runSampleAppPush(app sampleApp) error {

--- a/internal/gonut/cmd/root.go
+++ b/internal/gonut/cmd/root.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/homeport/gonut/internal/gonut/cf"
 	"github.com/homeport/gonvenience/pkg/v1/bunt"
 )
 
@@ -49,4 +50,18 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+// ExitGonut leaves gonut in case of an unresolvable error situation
+func ExitGonut(reason interface{}) {
+	switch typed := reason.(type) {
+	case *cf.ErrorWithDetails:
+		bunt.Printf("*Error:* _%s_\n", typed.Caption)
+		bunt.Printf("%s\n\n", typed.Details)
+
+	default:
+		fmt.Println(reason)
+	}
+
+	os.Exit(1)
 }


### PR DESCRIPTION
Add errors Go file with custom type of error.

Use custom type error that comes with caption and details.

Replace Wrap and Wrapf calls with new custom type.

Unify error messages and look and feel.

Introduce common exit on error function.