### PR TITLE
Introduce cleanup command

### DIFF
--- a/assets/test/cf-curl/v2/apps/apps-page.json
+++ b/assets/test/cf-curl/v2/apps/apps-page.json
@@ -1,0 +1,163 @@
+{
+   "total_results": 3,
+   "total_pages": 1,
+   "prev_url": null,
+   "next_url": null,
+   "resources": [
+      {
+         "metadata": {
+            "guid": "70cf57b9-536d-4294-ae8c-b67646f7a903",
+            "url": "/v2/apps/70cf57b9-536d-4294-ae8c-b67646f7a903",
+            "created_at": "2018-11-15T16:28:35Z",
+            "updated_at": "2018-11-15T16:28:45Z"
+         },
+         "entity": {
+            "name": "prometheus-test-exporter",
+            "production": false,
+            "space_guid": "1a0be5ce-b656-4f31-9e93-26d86f1d0b0d",
+            "stack_guid": "b27fa30f-9cb2-4119-a80b-1d168fb39ba3",
+            "buildpack": "php_buildpack",
+            "detected_buildpack": "",
+            "detected_buildpack_guid": "a50703d1-68ff-41d2-b740-79d7ada3509a",
+            "environment_json": {
+               "redacted_message": "[PRIVATE DATA HIDDEN]"
+            },
+            "memory": 64,
+            "instances": 1,
+            "disk_quota": 256,
+            "state": "STARTED",
+            "version": "0e8ee1cd-56a9-452f-a4d6-39825aa40247",
+            "command": null,
+            "console": false,
+            "debug": null,
+            "staging_task_id": "6e97bd2f-c168-428a-a5c0-623909d54a58",
+            "package_state": "STAGED",
+            "health_check_type": "port",
+            "health_check_timeout": null,
+            "health_check_http_endpoint": null,
+            "staging_failed_reason": null,
+            "staging_failed_description": null,
+            "diego": true,
+            "docker_image": null,
+            "docker_credentials": {
+               "username": null,
+               "password": null
+            },
+            "package_updated_at": "2018-11-15T16:28:40Z",
+            "detected_start_command": "$HOME/.bp/bin/start",
+            "enable_ssh": true,
+            "ports": [
+               8080
+            ],
+            "space_url": "/v2/spaces/1a0be5ce-b656-4f31-9e93-26d86f1d0b0d",
+            "stack_url": "/v2/stacks/b27fa30f-9cb2-4119-a80b-1d168fb39ba3",
+            "routes_url": "/v2/apps/70cf57b9-536d-4294-ae8c-b67646f7a903/routes",
+            "events_url": "/v2/apps/70cf57b9-536d-4294-ae8c-b67646f7a903/events",
+            "service_bindings_url": "/v2/apps/70cf57b9-536d-4294-ae8c-b67646f7a903/service_bindings",
+            "route_mappings_url": "/v2/apps/70cf57b9-536d-4294-ae8c-b67646f7a903/route_mappings"
+         }
+      },
+      {
+         "metadata": {
+            "guid": "81881bf1-e800-42cb-a3c1-fa10cbcff165",
+            "url": "/v2/apps/81881bf1-e800-42cb-a3c1-fa10cbcff165",
+            "created_at": "2019-04-14T09:46:57Z",
+            "updated_at": "2019-04-14T09:47:02Z"
+         },
+         "entity": {
+            "name": "gonut-nodejs-app-egstkqbnpuexbgc",
+            "production": false,
+            "space_guid": "55b6988c-d7d8-4eab-89bd-2e41e81f4fdc",
+            "stack_guid": "b27fa30f-9cb2-4119-a80b-1d168fb39ba3",
+            "buildpack": null,
+            "detected_buildpack": "SDK for Node.js(TM) (node.js-6.17.0, buildpack-v3.26-20190313-1440)",
+            "detected_buildpack_guid": "4977030c-59cd-479a-8276-39dfbeb793a9",
+            "environment_json": {},
+            "memory": 128,
+            "instances": 1,
+            "disk_quota": 128,
+            "state": "STARTED",
+            "version": "77fa02b3-bb23-4221-8555-d8ca6841cd12",
+            "command": "node app.js",
+            "console": false,
+            "debug": null,
+            "staging_task_id": "fec58f9e-cdd9-468d-ac5c-b72a01bbedce",
+            "package_state": "STAGED",
+            "health_check_type": "port",
+            "health_check_timeout": null,
+            "health_check_http_endpoint": null,
+            "staging_failed_reason": null,
+            "staging_failed_description": null,
+            "diego": true,
+            "docker_image": null,
+            "docker_credentials": {
+               "username": null,
+               "password": null
+            },
+            "package_updated_at": "2019-04-14T09:46:57Z",
+            "detected_start_command": "npm start",
+            "enable_ssh": true,
+            "ports": [
+               8080
+            ],
+            "space_url": "/v2/spaces/55b6988c-d7d8-4eab-89bd-2e41e81f4fdc",
+            "stack_url": "/v2/stacks/b27fa30f-9cb2-4119-a80b-1d168fb39ba3",
+            "routes_url": "/v2/apps/81881bf1-e800-42cb-a3c1-fa10cbcff165/routes",
+            "events_url": "/v2/apps/81881bf1-e800-42cb-a3c1-fa10cbcff165/events",
+            "service_bindings_url": "/v2/apps/81881bf1-e800-42cb-a3c1-fa10cbcff165/service_bindings",
+            "route_mappings_url": "/v2/apps/81881bf1-e800-42cb-a3c1-fa10cbcff165/route_mappings"
+         }
+      },
+      {
+         "metadata": {
+            "guid": "fac3c81c-61e8-4f07-9522-3e6ff21783cd",
+            "url": "/v2/apps/fac3c81c-61e8-4f07-9522-3e6ff21783cd",
+            "created_at": "2019-04-14T09:46:58Z",
+            "updated_at": "2019-04-14T09:47:02Z"
+         },
+         "entity": {
+            "name": "gonut-nodejs-app-klsbzxnzpbizhsu",
+            "production": false,
+            "space_guid": "55b6988c-d7d8-4eab-89bd-2e41e81f4fdc",
+            "stack_guid": "b27fa30f-9cb2-4119-a80b-1d168fb39ba3",
+            "buildpack": null,
+            "detected_buildpack": "SDK for Node.js(TM) (node.js-6.17.0, buildpack-v3.26-20190313-1440)",
+            "detected_buildpack_guid": "4977030c-59cd-479a-8276-39dfbeb793a9",
+            "environment_json": {},
+            "memory": 128,
+            "instances": 1,
+            "disk_quota": 128,
+            "state": "STARTED",
+            "version": "ed625da5-5d92-4c7d-a390-e27256ea42ca",
+            "command": "node app.js",
+            "console": false,
+            "debug": null,
+            "staging_task_id": "e3a09d2e-618b-4d12-8051-e628db137ff6",
+            "package_state": "STAGED",
+            "health_check_type": "port",
+            "health_check_timeout": null,
+            "health_check_http_endpoint": null,
+            "staging_failed_reason": null,
+            "staging_failed_description": null,
+            "diego": true,
+            "docker_image": null,
+            "docker_credentials": {
+               "username": null,
+               "password": null
+            },
+            "package_updated_at": "2019-04-14T09:46:58Z",
+            "detected_start_command": "npm start",
+            "enable_ssh": true,
+            "ports": [
+               8080
+            ],
+            "space_url": "/v2/spaces/55b6988c-d7d8-4eab-89bd-2e41e81f4fdc",
+            "stack_url": "/v2/stacks/b27fa30f-9cb2-4119-a80b-1d168fb39ba3",
+            "routes_url": "/v2/apps/fac3c81c-61e8-4f07-9522-3e6ff21783cd/routes",
+            "events_url": "/v2/apps/fac3c81c-61e8-4f07-9522-3e6ff21783cd/events",
+            "service_bindings_url": "/v2/apps/fac3c81c-61e8-4f07-9522-3e6ff21783cd/service_bindings",
+            "route_mappings_url": "/v2/apps/fac3c81c-61e8-4f07-9522-3e6ff21783cd/route_mappings"
+         }
+      }
+   ]
+}

--- a/internal/gonut/cf/model_test.go
+++ b/internal/gonut/cf/model_test.go
@@ -23,6 +23,7 @@ package cf_test
 import (
 	"encoding/json"
 	"io/ioutil"
+	"reflect"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -39,6 +40,16 @@ var _ = Describe("Cloud Foundry JSON structs and contracts", func() {
 			var app AppDetails
 			Expect(json.Unmarshal(data, &app)).ToNot(HaveOccurred())
 			Expect(app.Entity.DetectedBuildpackGUID).To(BeEquivalentTo("6b70e2d7-1c63-4af9-b06d-37ae841ca8ae"))
+		})
+
+		It("should parse Cloud Foundry API page of apps details", func() {
+			data, err := ioutil.ReadFile("../../../assets/test/cf-curl/v2/apps/apps-page.json")
+			Expect(err).ToNot(HaveOccurred())
+
+			var appsPage AppsPage
+			var apps []AppDetails
+			Expect(json.Unmarshal(data, &appsPage)).ToNot(HaveOccurred())
+			Expect(reflect.TypeOf(appsPage.Resources)).To(BeEquivalentTo(reflect.TypeOf(apps)))
 		})
 
 		It("should parse Cloud Foundry API buildpacks details", func() {

--- a/internal/gonut/cf/models.go
+++ b/internal/gonut/cf/models.go
@@ -166,3 +166,12 @@ type StackDetails struct {
 		Description string `json:"description"`
 	} `json:"entity"`
 }
+
+// AppsPage represents the result from cf curl /v2/apps page
+type AppsPage struct {
+	// TotalResults string `json:"total_results"`
+	// TotalPages string `json:"total_pages"`
+	// PrevURL     string       `json:"prev_url"`
+	NextURL   string       `json:"next_url"`
+	Resources []AppDetails `json:"resources"`
+}

--- a/internal/gonut/cmd/cleanup.go
+++ b/internal/gonut/cmd/cleanup.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/homeport/gonut/internal/gonut/cf"
+	"github.com/spf13/cobra"
+)
+
+// cleanUpCmd represents the cleanup command
+var cleanUpCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Delete all gonut pushed apps",
+	Run:   cleanUp,
+}
+
+func init() {
+	rootCmd.AddCommand(cleanUpCmd)
+}
+
+func cleanUp(cmd *cobra.Command, args []string) {
+	apps, _ := cf.GetApps()
+	var appsToClean, _ = getGonutApps(apps, GonutAppPrefix)
+	if err := cf.DeleteApps(appsToClean); err != nil {
+
+	}
+}
+
+func getGonutApps(apps []cf.AppDetails, prefix string) ([]cf.AppDetails, error) {
+	gonutApps := apps[:0]
+	for _, app := range apps {
+
+		if strings.HasPrefix(app.Entity.Name, prefix) {
+			gonutApps = append(gonutApps, app)
+		}
+	}
+	return gonutApps, nil
+}

--- a/internal/gonut/cmd/push.go
+++ b/internal/gonut/cmd/push.go
@@ -34,6 +34,10 @@ import (
 	"github.com/homeport/pina-golada/pkg/files"
 )
 
+//GonutAppPrefix is the prefeix for gonuts applications, it is also used by
+//the cleanup command to decide whether an app is pushed by gonut or not
+var GonutAppPrefix = "gonut"
+
 type sampleApp struct {
 	caption       string
 	command       string
@@ -52,7 +56,7 @@ var sampleApps = []sampleApp{
 		caption:       "Golang",
 		command:       "golang",
 		aliases:       []string{"go"},
-		appNamePrefix: "gonut-golang-app-",
+		appNamePrefix: fmt.Sprintf("%s-golang-app-", GonutAppPrefix),
 		assetFunc:     assets.Provider.GoSampleApp,
 	},
 
@@ -60,7 +64,7 @@ var sampleApps = []sampleApp{
 		caption:       "Python",
 		command:       "python",
 		aliases:       []string{},
-		appNamePrefix: "gonut-python-app-",
+		appNamePrefix: fmt.Sprintf("%s-python-app-", GonutAppPrefix),
 		assetFunc:     assets.Provider.PythonSampleApp,
 	},
 
@@ -68,7 +72,7 @@ var sampleApps = []sampleApp{
 		caption:       "PHP",
 		command:       "php",
 		aliases:       []string{},
-		appNamePrefix: "gonut-php-app-",
+		appNamePrefix: fmt.Sprintf("%s-php-app-", GonutAppPrefix),
 		assetFunc:     assets.Provider.PHPSampleApp,
 	},
 
@@ -76,7 +80,7 @@ var sampleApps = []sampleApp{
 		caption:       "Staticfile",
 		command:       "staticfile",
 		aliases:       []string{"static"},
-		appNamePrefix: "gonut-staticfile-app-",
+		appNamePrefix: fmt.Sprintf("%s-staticfile-app-", GonutAppPrefix),
 		assetFunc:     assets.Provider.StaticfileSampleApp,
 	},
 
@@ -84,7 +88,7 @@ var sampleApps = []sampleApp{
 		caption:       "Swift",
 		command:       "swift",
 		aliases:       []string{},
-		appNamePrefix: "gonut-swift-app-",
+		appNamePrefix: fmt.Sprintf("%s-swift-app-", GonutAppPrefix),
 		assetFunc:     assets.Provider.SwiftSampleApp,
 	},
 
@@ -92,14 +96,14 @@ var sampleApps = []sampleApp{
 		caption:       "NodeJS",
 		command:       "nodejs",
 		aliases:       []string{"node"},
-		appNamePrefix: "gonut-nodejs-app-",
+		appNamePrefix: fmt.Sprintf("%s-nodejs-app-", GonutAppPrefix),
 		assetFunc:     assets.Provider.NodeJSSampleApp,
 	},
 
 	{
 		caption:       "Ruby",
 		command:       "ruby",
-		appNamePrefix: "gonut-ruby-sinatra-app-",
+		appNamePrefix: fmt.Sprintf("%s-ruby-sinatra-app-", GonutAppPrefix),
 		assetFunc:     assets.Provider.RubySampleApp,
 	},
 }


### PR DESCRIPTION
Add cleanup command to delete gonut apps and the mapped routes,
the deletion is based on a predefined prefix of the pushed apps.
The usage is as simple as `gonut cleanup`.