### PR TITLE
Bump dependency versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/homeport/gonut
 
 require (
-	github.com/homeport/gonvenience v1.7.4
-	github.com/homeport/pina-golada v1.2.6
+	github.com/homeport/gonvenience v1.7.5
+	github.com/homeport/pina-golada v1.2.7
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.0 h1:kbxbvI4Un1LUWKxufD+BiE6AEExYYgkQLQmLFqA1LFk=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/homeport/gonvenience v1.6.0/go.mod h1:G2NH1mGKb2RtQ/xy7Axv5Tnnwzq4yE6NoYyINd1Lvuk=
-github.com/homeport/gonvenience v1.7.4 h1:23L+d9Ydb4mmceYc7l+hAuCuH08H8ol8c+QX90Yv61o=
-github.com/homeport/gonvenience v1.7.4/go.mod h1:G2NH1mGKb2RtQ/xy7Axv5Tnnwzq4yE6NoYyINd1Lvuk=
-github.com/homeport/pina-golada v1.2.6 h1:KAi3oilEfgapqtBqnJKktiaSnKjuBTb050/Wao6UXu0=
-github.com/homeport/pina-golada v1.2.6/go.mod h1:+Zmz4kCgsKh0eqXO31XZcc49u9k0CmGtoW/ZWatUxH4=
+github.com/homeport/gonvenience v1.7.5 h1:ZUZujX7RQc4JIE3bZWHUaGUmorbVTmlbXBiHJEpwq1A=
+github.com/homeport/gonvenience v1.7.5/go.mod h1:G2NH1mGKb2RtQ/xy7Axv5Tnnwzq4yE6NoYyINd1Lvuk=
+github.com/homeport/pina-golada v1.2.7 h1:BJUaL4ZyXE2kAVb02YofVIYHQyEcdP+MyLnnILFiRN0=
+github.com/homeport/pina-golada v1.2.7/go.mod h1:+Zmz4kCgsKh0eqXO31XZcc49u9k0CmGtoW/ZWatUxH4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=


### PR DESCRIPTION
Bump dependency versions of `gonvenience` and `pina-golada`.

	github.com/homeport/gonvenience v1.7.5
	github.com/homeport/pina-golada v1.2.7