### PR TITLE
Different Formats for Push Summary Report

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/spf13/cobra v0.0.5
+	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/homeport/gonut
 go 1.12
 
 require (
-	github.com/gonvenience/bunt v1.0.6
+	github.com/gonvenience/bunt v1.0.7
 	github.com/gonvenience/neat v1.0.3
 	github.com/gonvenience/term v1.0.0
 	github.com/gonvenience/text v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,9 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/gonvenience/bunt v1.0.6 h1:b3KEkaSlbXx3m4s2Gg5NfKkbo3YR3daCbqeecbDG9IE=
 github.com/gonvenience/bunt v1.0.6/go.mod h1:lsyhkmNpSAzhVx059BD0fQy5F29rWcS6AHb7UWNlT/s=
+github.com/gonvenience/bunt v1.0.7 h1:g4xg5OlNNNGNnwRZ/F4r3inRgnbfrbjnw1lO4BODmb4=
+github.com/gonvenience/bunt v1.0.7/go.mod h1:lsyhkmNpSAzhVx059BD0fQy5F29rWcS6AHb7UWNlT/s=
 github.com/gonvenience/neat v1.0.3 h1:1ksHRuOGuUQEiHjXKwlsNoFGpZaxE8e9Gvc+6ktU7c8=
 github.com/gonvenience/neat v1.0.3/go.mod h1:QBRLwRxib88dGjs/1ncOjPxDsCUch/0CGJUvg2iOYXY=
 github.com/gonvenience/term v1.0.0 h1:joCB/j0Ngmdakd3muuLgAGPMf7DNKdoe708c1I6RiBs=
@@ -84,6 +85,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/internal/gonut/cf/report.go
+++ b/internal/gonut/cf/report.go
@@ -21,9 +21,21 @@
 package cf
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+//OutputType report output type
+type OutputType int
+
+// Currently, we support JSON and YAML
+const (
+	JSON = OutputType(iota)
+	YAML
 )
 
 // PushReport encapsules details of a Cloud Foundry push command
@@ -125,4 +137,14 @@ func (report *PushReport) HasTimeDetails() bool {
 		report.UploadingTime() > time.Duration(0) &&
 		report.StagingTime() > time.Duration(0) &&
 		report.StartingTime() > time.Duration(0)
+}
+
+//ToJSON marshall PushReport as json
+func (report *PushReport) ToJSON() ([]byte, error) {
+	return json.Marshal(&report)
+}
+
+//ToYAML marshall PushReport as yaml
+func (report *PushReport) ToYAML() ([]byte, error) {
+	return yaml.Marshal(&report)
 }

--- a/internal/gonut/cf/report.go
+++ b/internal/gonut/cf/report.go
@@ -21,21 +21,11 @@
 package cf
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"gopkg.in/yaml.v2"
-)
-
-//OutputType report output type
-type OutputType int
-
-// Currently, we support JSON and YAML
-const (
-	JSON = OutputType(iota)
-	YAML
 )
 
 // PushReport encapsules details of a Cloud Foundry push command
@@ -139,12 +129,22 @@ func (report *PushReport) HasTimeDetails() bool {
 		report.StartingTime() > time.Duration(0)
 }
 
-//ToJSON marshall PushReport as json
-func (report *PushReport) ToJSON() ([]byte, error) {
-	return json.Marshal(&report)
-}
+// Export creates a less technical representation of the report
+func (report *PushReport) Export() yaml.MapSlice {
+	result := yaml.MapSlice{
+		yaml.MapItem{Key: "stack", Value: report.Stack()},
+		yaml.MapItem{Key: "buildpack", Value: report.Buildpack()},
+	}
 
-//ToYAML marshall PushReport as yaml
-func (report *PushReport) ToYAML() ([]byte, error) {
-	return yaml.Marshal(&report)
+	if report.HasTimeDetails() {
+		result = append(result,
+			yaml.MapItem{Key: "ramp-up", Value: report.InitTime()},
+			yaml.MapItem{Key: "creating", Value: report.CreatingTime()},
+			yaml.MapItem{Key: "uploading", Value: report.UploadingTime()},
+			yaml.MapItem{Key: "staging", Value: report.StagingTime()},
+			yaml.MapItem{Key: "starting", Value: report.StartingTime()},
+		)
+	}
+
+	return result
 }

--- a/internal/gonut/cmd/push.go
+++ b/internal/gonut/cmd/push.go
@@ -220,7 +220,7 @@ func runSampleAppPush(app sampleApp) error {
 		return err
 	}
 
-	switch summarySetting {
+	switch strings.ToLower(summarySetting) {
 	case "quiet":
 		// Nothing to report
 
@@ -229,6 +229,22 @@ func runSampleAppPush(app sampleApp) error {
 			app.caption,
 			humanReadableDuration(report.ElapsedTime()),
 		)
+
+	case "json":
+		out, err := neat.NewOutputProcessor(true, true, &neat.DefaultColorSchema).ToJSON(report.Export())
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(out)
+
+	case "yaml":
+		out, err := neat.ToYAMLString(report.Export())
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(out)
 
 	case "full":
 		var buf bytes.Buffer


### PR DESCRIPTION
Currently, we only have a human readable format for the push summary.
In this PR, we add support of JSON and YAML.

Example Usage:
 gonut push ruby --summary full --output json
 gonut push ruby --summary full --output yaml