### PR TITLE
Sync pina-golada version of code and build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 - 1.12.x
 
 install:
-- curl -fsL https://ibm.biz/Bd2645 | bash -s v1.2.6 # pina-golada
+- curl -fsL https://ibm.biz/Bd2645 | bash -s v1.2.7 # pina-golada
 - curl -fsL https://goo.gl/g1CpPX | bash -s v1.0.7 # golang-dev-tools
 
 script:


### PR DESCRIPTION
The pina-golada Go package being used during runtime should be in sync
with the one used for the build. Set version v1.2.7 to be used by the
build.