### PR TITLE
Add verbose flag

### DIFF
--- a/internal/gonut/cmd/cleanup.go
+++ b/internal/gonut/cmd/cleanup.go
@@ -32,7 +32,7 @@ func cleanUp(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := cf.DeleteApps(appsToClean); err != nil {
+	if err := cf.DeleteApps(appsToClean, Verbose); err != nil {
 		return err
 	}
 

--- a/internal/gonut/cmd/push.go
+++ b/internal/gonut/cmd/push.go
@@ -189,7 +189,7 @@ func runSampleAppPush(app sampleApp) error {
 		return err
 	}
 
-	report, err := cf.PushApp(app.caption, appName, directory, cleanupSetting)
+	report, err := cf.PushApp(app.caption, appName, directory, cleanupSetting, Verbose)
 	if err != nil {
 		return err
 	}

--- a/internal/gonut/cmd/root.go
+++ b/internal/gonut/cmd/root.go
@@ -43,9 +43,13 @@ It is written in Golang and uses CornflowerBlue{~https://github.com/homeport/pin
 include arbitrary sample app data in the application binary.`),
 }
 
+// Verbose is a global flag for all commands to indicate whether to be verbose or not
+var Verbose bool
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Now, by default, when pushing or cleaning up gonut apps, the output
will not be verbose. This change is a prerequisite to finish PR: #40

This PR is on top of https://github.com/homeport/gonut/pull/43