### PR TITLE
Bump to pina-golada v1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 - 1.12.x
 
 install:
-- curl -fsL https://ibm.biz/Bd2645 | bash -s v1.2.6 # pina-golada
+- curl -fsL https://ibm.biz/Bd2645 | bash -s v1.3.2 # pina-golada
 - curl -fsL https://goo.gl/g1CpPX | bash -s v1.0.7 # golang-dev-tools
 
 script:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/homeport/gonut
 
 require (
 	github.com/homeport/gonvenience v1.7.5
-	github.com/homeport/pina-golada v1.2.7
+	github.com/homeport/pina-golada v1.3.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a
 github.com/homeport/gonvenience v1.6.0/go.mod h1:G2NH1mGKb2RtQ/xy7Axv5Tnnwzq4yE6NoYyINd1Lvuk=
 github.com/homeport/gonvenience v1.7.5 h1:ZUZujX7RQc4JIE3bZWHUaGUmorbVTmlbXBiHJEpwq1A=
 github.com/homeport/gonvenience v1.7.5/go.mod h1:G2NH1mGKb2RtQ/xy7Axv5Tnnwzq4yE6NoYyINd1Lvuk=
-github.com/homeport/pina-golada v1.2.7 h1:BJUaL4ZyXE2kAVb02YofVIYHQyEcdP+MyLnnILFiRN0=
-github.com/homeport/pina-golada v1.2.7/go.mod h1:+Zmz4kCgsKh0eqXO31XZcc49u9k0CmGtoW/ZWatUxH4=
+github.com/homeport/pina-golada v1.3.2 h1:Zm5Y5sCGiEMXbsSSTJv7bt6bCXxhGNXjwzegrZLtC2U=
+github.com/homeport/pina-golada v1.3.2/go.mod h1:+Zmz4kCgsKh0eqXO31XZcc49u9k0CmGtoW/ZWatUxH4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=


### PR DESCRIPTION
Bump to `pina-golada` version `v1.3.2` (both generate and package).

The pina-golada Go package being used during runtime should be in sync
with the one used for the build. Set version v1.3.2 to be used by the
build.