### PR TITLE
Add codecov.io coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ script:
 - go mod verify
 - make test
 
+after_success:
+- for FILE in $(find . -type f -name "*.coverprofile" 2>/dev/null); do echo >>$FILE; done
+- gover . coverage.txt
+- bash <(curl -s https://codecov.io/bash)
+
 before_deploy:
 - make build
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,13 +26,14 @@ echo -e '\n\033[1mCompiling assets:\033[0m'
 pina-golada generate
 
 GO111MODULE=on ginkgo -r \
-  --randomizeAllSpecs \
-  --randomizeSuites \
-  --failOnPending \
-  --nodes=4 \
-  --compilers=2 \
-  --race \
-  --trace
+  -randomizeAllSpecs \
+  -randomizeSuites \
+  -failOnPending \
+  -nodes=4 \
+  -compilers=2 \
+  -race \
+  -trace \
+  -cover
 
 pina-golada cleanup
 echo -e '\n\033[1mCleaned up assets\033[0m'


### PR DESCRIPTION
Add `-cover` option to ginkgo and basic codecov.io setup in Travis.